### PR TITLE
Improve HTML markup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,15 +36,15 @@
                 <img src="img/logo.png" alt="Logo" id="logo" height="400" width="258"/>
 
                 <div class="content-box">
-                    <p class="lead" align="justify">
-                        Jaa !mproteater on Eesti teatrimaastikul tegutsenud aastast 2009 (enne 2016 nimega Improgrupp Jaa!). 
-                        Olles üks esimesi ja vanimaid improteatreid Eestis, on Jaa!l olnud määrav osa kohaliku improkultuuri arendamisel ja suunamisel.  
-                        Jaa! on andnud etendusi nii Eestis kui välismaal, toonud kohaliku publiku ette nii koolitajaid kui teatritruppe teistest riikidest ning korraldanud rahvusvahelist improteatrite festivali Tilt. 
-                        <br>
-                        <br>
-                        Etenduste formaatides pakub Jaa! publikule võimalust saada osa nii lühivormi sketšidest kui pikavormi etendustest. 
-                        <br>
-                        <br>
+                    <p class="lead text-justify">
+                        Jaa !mproteater on Eesti teatrimaastikul tegutsenud aastast 2009 (enne 2016 nimega Improgrupp Jaa!).
+                        Olles üks esimesi ja vanimaid improteatreid Eestis, on Jaa!l olnud määrav osa kohaliku improkultuuri arendamisel ja suunamisel.
+                        Jaa! on andnud etendusi nii Eestis kui välismaal, toonud kohaliku publiku ette nii koolitajaid kui teatritruppe teistest riikidest ning korraldanud rahvusvahelist <a href="http://improfestival.ee/">improteatrite festivali Tilt.</a>
+                    </p>
+                    <p class="lead text-justify">
+                        Etenduste formaatides pakub Jaa! publikule võimalust saada osa nii lühivormi sketšidest kui pikavormi etendustest.
+                    </p>
+                    <p class="lead text-justify">
                         Jaa !mproteater on alati valmis väljakutseteks ning otsib huviga uusi vorme ja võimalusi spontaansete teatrihetkede jagamiseks!
                     </p>
 


### PR DESCRIPTION
Usage of the `align` attribute is discouraged in HTML5. Use CSS markup class instead. Use paragraph tags for paragraph breaks.
